### PR TITLE
Synchronise content server instance

### DIFF
--- a/mentalabMobileApi/src/main/java/com/mentalab/service/ConfigureChannelCountTask.java
+++ b/mentalabMobileApi/src/main/java/com/mentalab/service/ConfigureChannelCountTask.java
@@ -2,9 +2,9 @@ package com.mentalab.service;
 
 import com.mentalab.DeviceManager;
 import com.mentalab.ExploreDevice;
+import com.mentalab.packets.Packet;
 import com.mentalab.service.io.ContentServer;
 import com.mentalab.service.io.Subscriber;
-import com.mentalab.packets.Packet;
 import com.mentalab.utils.Utils;
 import com.mentalab.utils.constants.ChannelCount;
 import com.mentalab.utils.constants.Topic;
@@ -38,6 +38,7 @@ public class ConfigureChannelCountTask implements Callable<Boolean> {
             final DeviceManager manager = new DeviceManager(device);
             manager.setDeviceChannelCount(channelCount);
             result = true;
+            latch.countDown();
           }
         };
     ContentServer.getInstance().registerSubscriber(channelCountSubscriber);

--- a/mentalabMobileApi/src/main/java/com/mentalab/service/ConfigureDeviceInfoTask.java
+++ b/mentalabMobileApi/src/main/java/com/mentalab/service/ConfigureDeviceInfoTask.java
@@ -2,10 +2,10 @@ package com.mentalab.service;
 
 import com.mentalab.DeviceManager;
 import com.mentalab.ExploreDevice;
-import com.mentalab.service.io.ContentServer;
-import com.mentalab.service.io.Subscriber;
 import com.mentalab.packets.Packet;
 import com.mentalab.packets.info.DeviceInfoPacket;
+import com.mentalab.service.io.ContentServer;
+import com.mentalab.service.io.Subscriber;
 import com.mentalab.utils.constants.Topic;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -34,8 +34,7 @@ public class ConfigureDeviceInfoTask implements Callable<Boolean> {
             new Subscriber(Topic.DEVICE_INFO) {
               @Override
               public void accept(Packet packet) {
-                DeviceManager configurator =
-                    new DeviceManager(device);
+                DeviceManager configurator = new DeviceManager(device);
                 configurator.setDeviceInfo((DeviceInfoPacket) packet);
                 result = true;
                 latch.countDown();

--- a/mentalabMobileApi/src/main/java/com/mentalab/service/io/ContentServer.java
+++ b/mentalabMobileApi/src/main/java/com/mentalab/service/io/ContentServer.java
@@ -2,26 +2,21 @@ package com.mentalab.service.io;
 
 import com.mentalab.packets.Packet;
 import com.mentalab.utils.constants.Topic;
-import java.util.HashMap;
-import java.util.HashSet;
+
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ContentServer {
 
-  private static ContentServer INSTANCE;
-  private final Map<Topic, Set<Subscriber>> topicSubscribers = new HashMap<>();
-
-  private ContentServer() {}
+  // it is a good idea to provide a size estimate as an optional initialCapacity
+  private final Map<Topic, Set<Subscriber>> topicSubscribers = new ConcurrentHashMap<>(5);
 
   public static ContentServer getInstance() {
-    if (INSTANCE == null) {
-      INSTANCE = new ContentServer();
-    }
-    return INSTANCE;
+    return InstanceHolder.INSTANCE;
   }
 
-  public synchronized void publish(Topic topic, Packet message) {
+  public void publish(Topic topic, Packet message) {
     final Set<Subscriber> subscribers = this.topicSubscribers.get(topic);
     if (subscribers == null) {
       return;
@@ -32,11 +27,22 @@ public class ContentServer {
     }
   }
 
-  public synchronized void registerSubscriber(Subscriber sub) {
-    this.topicSubscribers.computeIfAbsent(sub.getTopic(), k -> new HashSet<>()).add(sub);
+  public void registerSubscriber(Subscriber sub) {
+    this.topicSubscribers
+            .computeIfAbsent(sub.getTopic(), k -> ConcurrentHashMap.newKeySet())
+            .add(sub);
   }
 
-  public synchronized void deRegisterSubscriber(Subscriber sub) {
-    this.topicSubscribers.get(sub.getTopic()).remove(sub);
+  public void deRegisterSubscriber(Subscriber sub) {
+    final Set<Subscriber> topicSubscribers = this.topicSubscribers.get(sub.getTopic());
+    if (topicSubscribers != null) {
+      topicSubscribers.remove(sub);
+    }
+  }
+
+  private ContentServer() {}
+
+  private static class InstanceHolder { // Initialization-on-demand synchronization
+    private static final ContentServer INSTANCE = new ContentServer();
   }
 }


### PR DESCRIPTION
Please have a look at this @salman2135 and tell me what you think. I removed the synchronized key word, because I think in this instance making the map and set concurrent is more appropriate. We can synchronize the methods all we like, but that just means the methods can only be called one at a time. It doesn't mean that the methods wouldn't interupt one another, which is where the concurrent map and set help

Based on tricky synchronization bug @salman2135 identified and resolved. 